### PR TITLE
Remove state from output

### DIFF
--- a/formatters/sorting.go
+++ b/formatters/sorting.go
@@ -18,13 +18,6 @@ func (rs ByName) Len() int           { return len(rs) }
 func (rs ByName) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
 func (rs ByName) Less(i, j int) bool { return rs[i].Name < rs[j].Name }
 
-// ByState implements sort.Interface for []providers.Request based on State.
-type ByState []providers.Request
-
-func (rs ByState) Len() int           { return len(rs) }
-func (rs ByState) Swap(i, j int)      { rs[i], rs[j] = rs[j], rs[i] }
-func (rs ByState) Less(i, j int) bool { return rs[i].State < rs[j].State }
-
 // ByURL implements sort.Interface for []providers.Request based on URL.
 type ByURL []providers.Request
 

--- a/formatters/table.go
+++ b/formatters/table.go
@@ -13,9 +13,9 @@ type Table struct{}
 
 // String returns the ASCII table t containing the given requests.
 func (t *Table) String(requests ...providers.Request) string {
-	rows := [][]string{{"Repository", "Name", "State", "URL", "Created", "Updated"}}
+	rows := [][]string{{"Repository", "Name", "URL", "Created", "Updated"}}
 	for _, r := range requests {
-		rows = append(rows, []string{r.Repository, r.Name, r.State, r.URL, r.Created.Format(time.UnixDate), r.Updated.Format(time.UnixDate)})
+		rows = append(rows, []string{r.Repository, r.Name, r.URL, r.Created.Format(time.UnixDate), r.Updated.Format(time.UnixDate)})
 	}
 
 	colWidths := map[int]int{}

--- a/main.go
+++ b/main.go
@@ -48,9 +48,6 @@ func main() {
 	case "name":
 		sort.Sort(formatters.ByName(requests))
 		break
-	case "state":
-		sort.Sort(formatters.ByState(requests))
-		break
 	case "url":
 		sort.Sort(formatters.ByURL(requests))
 		break

--- a/providers/github/client.go
+++ b/providers/github/client.go
@@ -24,7 +24,6 @@ type Client struct {
 // pullRequest serves as Unmarshal target type when reading Github API responses
 type pullRequest struct {
 	Name    string    `json:"title"`
-	State   string    `json:"state"`
 	URL     string    `json:"url"`
 	Created time.Time `json:"created_at"`
 	Updated time.Time `json:"updated_at"`
@@ -142,7 +141,6 @@ func (c *Client) getRequests(repos string) ([]providers.Request, error) {
 			result = append(result, providers.Request{
 				Repository: repos,
 				Name:       r.Name,
-				State:      r.State,
 				URL:        r.URL,
 				Created:    r.Created,
 				Updated:    r.Updated,

--- a/providers/gitlab/client.go
+++ b/providers/gitlab/client.go
@@ -28,7 +28,6 @@ type repository struct {
 // mergeRequest serves as Unmarshal target type when reading Gitlab API responses
 type mergeRequest struct {
 	Name    string    `json:"title"`
-	State   string    `json:"state"`
 	URL     string    `json:"web_url"`
 	Created time.Time `json:"created_at"`
 	Updated time.Time `json:"updated_at"`
@@ -152,7 +151,6 @@ func (c *Client) getRequests(repos repository) ([]providers.Request, error) {
 			result = append(result, providers.Request{
 				Repository: repos.Name,
 				Name:       r.Name,
-				State:      r.State,
 				URL:        r.URL,
 				Created:    r.Created,
 				Updated:    r.Updated,

--- a/providers/types.go
+++ b/providers/types.go
@@ -8,7 +8,6 @@ import (
 type Request struct {
 	Repository string
 	Name       string
-	State      string
 	URL        string
 	Created    time.Time
 	Updated    time.Time


### PR DESCRIPTION
Since we only fetch open requests, theres no point in showing the state.