### PR TITLE
Use html template engine

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -2,7 +2,7 @@ package html
 
 import (
 	"bytes"
-	"text/template"
+	"html/template"
 
 	"github.com/cego/git-request-list/formatters"
 	"github.com/cego/git-request-list/request"


### PR DESCRIPTION
Currently `text/template` is used for the HTML formatter. This PR will change that to `html/template` to ensure correct HTML encoding.