### PR TITLE
Compact time display in HTML output

### DIFF
--- a/formatters/formatters.go
+++ b/formatters/formatters.go
@@ -2,6 +2,7 @@ package formatters
 
 import (
 	"errors"
+	"time"
 
 	"github.com/cego/git-request-list/request"
 )
@@ -11,8 +12,14 @@ type Formatter interface {
 	String() string
 }
 
+// Arguments defines what a formatter need to know to generate its output.
+type Arguments struct {
+	Requests []request.Request
+	Timezone *time.Location
+}
+
 // FormatterFactory types a function for producing new Formatters
-type FormatterFactory func(requests []request.Request) (Formatter, error)
+type FormatterFactory func(arguments Arguments) (Formatter, error)
 
 var factories map[string]FormatterFactory
 
@@ -26,11 +33,11 @@ func RegisterFormatter(identifier string, factory FormatterFactory) {
 }
 
 // GetFormatter gets a Formatter implementation of a type previously registered with RegisterFormatter
-func GetFormatter(identifier string, requests []request.Request) (Formatter, error) {
+func GetFormatter(identifier string, arguments Arguments) (Formatter, error) {
 	factory, exists := factories[identifier]
 	if !exists {
 		return nil, errors.New("unknown provider identifier")
 	}
 
-	return factory(requests)
+	return factory(arguments)
 }

--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -5,7 +5,6 @@ import (
 	"html/template"
 
 	"github.com/cego/git-request-list/formatters"
-	"github.com/cego/git-request-list/request"
 )
 
 // Table represents a HTML table containing pull- and merge-requests.
@@ -32,8 +31,8 @@ const htmlTemplate = `
         <td class="item-repository">{{.Repository}}</td>
         <td class="item-name">{{.Name}}</td>
         <td class="item-url">{{.URL}}</td>
-        <td class="item-created">{{.Created}}</td>
-        <td class="item-updated">{{.Updated}}</td>
+        <td class="item-created">{{(.Created.In $.Timezone).Format "2006-01-02 15:04"}}</td>
+        <td class="item-updated">{{(.Updated.In $.Timezone).Format "2006-01-02 15:04"}}</td>
       </tr>
       {{end}}
     </table>
@@ -44,11 +43,10 @@ const htmlTemplate = `
 func init() {
 	tmpl := template.Must(template.New("html").Parse(htmlTemplate))
 
-	factory := func(requests []request.Request) (formatters.Formatter, error) {
+	factory := func(arguments formatters.Arguments) (formatters.Formatter, error) {
 		// Compile htmlTemplate into buff
-		data := struct{ Requests []request.Request }{Requests: requests}
 		var buffer bytes.Buffer
-		err := tmpl.Execute(&buffer, data)
+		err := tmpl.Execute(&buffer, arguments)
 		if err != nil {
 			return nil, err
 		}

--- a/formatters/text/text.go
+++ b/formatters/text/text.go
@@ -6,18 +6,17 @@ import (
 	"unicode/utf8"
 
 	"github.com/cego/git-request-list/formatters"
-	"github.com/cego/git-request-list/request"
 )
 
 // Table represents an ASCII table containing pull- and merge-requests.
 type Table struct {
-	requests []request.Request
+	arguments formatters.Arguments
 }
 
 func init() {
-	factory := func(requests []request.Request) (formatters.Formatter, error) {
+	factory := func(arguments formatters.Arguments) (formatters.Formatter, error) {
 		t := Table{}
-		t.requests = requests
+		t.arguments = arguments
 
 		return &t, nil
 	}
@@ -28,8 +27,14 @@ func init() {
 // String returns the ASCII string that t represents.
 func (t *Table) String() string {
 	rows := [][]string{{"Repository", "Name", "URL", "Created", "Updated"}}
-	for _, r := range t.requests {
-		rows = append(rows, []string{r.Repository, r.Name, r.URL, r.Created.Format(time.UnixDate), r.Updated.Format(time.UnixDate)})
+	for _, r := range t.arguments.Requests {
+		rows = append(rows, []string{
+			r.Repository,
+			r.Name,
+			r.URL,
+			r.Created.In(t.arguments.Timezone).Format(time.UnixDate),
+			r.Updated.In(t.arguments.Timezone).Format(time.UnixDate),
+		})
 	}
 
 	colWidths := map[int]int{}

--- a/main.go
+++ b/main.go
@@ -49,11 +49,16 @@ func main() {
 
 	formatters.Sort(requests, conf.SortBy)
 
+	arguments := formatters.Arguments{
+		Requests: requests,
+		Timezone: conf.Timezone,
+	}
+
 	var formatter formatters.Formatter
 	if conf.Format == "" {
-		formatter, err = formatters.GetFormatter("text", requests)
+		formatter, err = formatters.GetFormatter("text", arguments)
 	} else {
-		formatter, err = formatters.GetFormatter(conf.Format, requests)
+		formatter, err = formatters.GetFormatter(conf.Format, arguments)
 	}
 	if err != nil {
 		log.Fatal(err)

--- a/readme.md
+++ b/readme.md
@@ -36,3 +36,4 @@ Each source can have the following properties:
 At top-level, you can specify the following properties:
   - `sort_by: <string>`: The property to sort output by. Either `repository`, `name`, `state`, `url`, `created` or `updated`.
   - `format: <string>`: The format of the output. Either `text` or `html`. Defaults to `text`.
+  - `timezone: <string>`: A timezone to normalize all timestamp in. Default to local timezone.


### PR DESCRIPTION
This PR contains the following:

- A new `formatters.Arguments` that can pass arguments to formatters.
- A more compact time display in HTML output.
- Support for nomalizing timezone for all requests.