### PR TITLE
Let the browser know we're using UTF-8

### DIFF
--- a/formatters/html/html.go
+++ b/formatters/html/html.go
@@ -15,6 +15,7 @@ type Table struct {
 const htmlTemplate = `
 <html>
   <head>
+    <meta charset="utf-8" /> 
     <link href="style.css" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
This should fix the problem of garbled UTF-8 characters.